### PR TITLE
feat: Add Azure OpenAI Base URL support

### DIFF
--- a/src/core/whisper_api.py
+++ b/src/core/whisper_api.py
@@ -19,7 +19,7 @@ class WhisperTranscriber:
         {"id": "gpt-4o-mini-transcribe", "name": "GPT-4o Mini Transcribe", "description": "Lightweight and fast transcription model"}
     ]
     
-    def __init__(self, api_key=None):
+    def __init__(self, api_key=None, base_url=None):
         """
         Whisper文字起こしクラスの初期化
         
@@ -27,15 +27,21 @@ class WhisperTranscriber:
         ----------
         api_key : str, optional
             OpenAI APIキー。提供されない場合はOPENAI_API_KEY環境変数から取得を試みます。
+        base_url : str, optional
+            OpenAI APIのベースURL。Azureなどで使用します。
         """
         # 提供されたAPIキーを使用するか、環境から取得
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self.base_url = base_url
         
         if not self.api_key:
             raise ValueError("OpenAI API key is required. Please provide it directly or set the OPENAI_API_KEY environment variable.")
         
         # OpenAIクライアントの初期化
-        self.client = openai.OpenAI(api_key=self.api_key)
+        if self.base_url:
+            self.client = openai.OpenAI(api_key=self.api_key, base_url=self.base_url)
+        else:
+            self.client = openai.OpenAI(api_key=self.api_key)
         
         # デフォルトパラメータの設定
         self.model = "whisper-1"  # 使用するWhisperモデル

--- a/src/gui/components/dialogs/api_key_dialog.py
+++ b/src/gui/components/dialogs/api_key_dialog.py
@@ -12,6 +12,7 @@ from PyQt6.QtCore import Qt
 
 from src.gui.resources.labels import AppLabels
 from src.gui.resources.styles import AppStyles
+from src.gui.resources.config import AppConfig
 
 class APIKeyDialog(QDialog):
     """
@@ -20,7 +21,7 @@ class APIKeyDialog(QDialog):
     APIキーの入力、保存、表示を管理するダイアログウィンドウ
     """
     
-    def __init__(self, parent=None, api_key=None):
+    def __init__(self, parent=None, api_key=None, current_base_url=AppConfig.DEFAULT_BASE_URL):
         """
         APIKeyDialogの初期化
         
@@ -30,14 +31,18 @@ class APIKeyDialog(QDialog):
             親ウィジェット
         api_key : str, optional
             初期表示するAPIキー
+        current_base_url : str, optional
+            初期表示するBase URL
         """
         super().__init__(parent)
         self.setWindowTitle(AppLabels.API_KEY_DIALOG_TITLE)
-        self.setMinimumWidth(400)
+        self.setMinimumWidth(450) # Adjusted width for new fields
         
         # スタイルシートを設定
         self.setStyleSheet(AppStyles.API_KEY_DIALOG_STYLE)
         
+        self.current_base_url = current_base_url
+
         layout = QVBoxLayout()
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(15)
@@ -45,19 +50,33 @@ class APIKeyDialog(QDialog):
         # APIキー入力
         form_layout = QFormLayout()
         form_layout.setSpacing(10)
+
         self.api_key_input = QLineEdit()
         if api_key:
             self.api_key_input.setText(api_key)
         self.api_key_input.setEchoMode(QLineEdit.EchoMode.Password)
         form_layout.addRow(AppLabels.API_KEY_LABEL, self.api_key_input)
         
+        # Base URL入力
+        base_url_label = QLabel(AppLabels.AZURE_BASE_URL_LABEL)
+        self.base_url_input = QLineEdit()
+        self.base_url_input.setPlaceholderText(AppLabels.AZURE_BASE_URL_PLACEHOLDER)
+        self.base_url_input.setText(self.current_base_url)
+        form_layout.addRow(base_url_label, self.base_url_input)
+
         layout.addLayout(form_layout)
         
-        # 情報テキスト
-        info_label = QLabel(AppLabels.API_KEY_INFO)
-        info_label.setWordWrap(True)
-        info_label.setStyleSheet(AppStyles.API_KEY_INFO_LABEL_STYLE)
-        layout.addWidget(info_label)
+        # APIキー情報テキスト
+        api_key_info_label = QLabel(AppLabels.API_KEY_INFO)
+        api_key_info_label.setWordWrap(True)
+        api_key_info_label.setStyleSheet(AppStyles.API_KEY_INFO_LABEL_STYLE)
+        layout.addWidget(api_key_info_label)
+
+        # Azure 情報テキスト
+        azure_info_label = QLabel(AppLabels.AZURE_INFO)
+        azure_info_label.setWordWrap(True)
+        azure_info_label.setStyleSheet(AppStyles.API_KEY_INFO_LABEL_STYLE) # Reuse style for now
+        layout.addWidget(azure_info_label)
         
         # ボタン
         button_layout = QHBoxLayout()
@@ -69,6 +88,7 @@ class APIKeyDialog(QDialog):
         self.cancel_button.setObjectName("cancelButton")
         self.cancel_button.clicked.connect(self.reject)
         
+        button_layout.addStretch(1) # Add stretch to push buttons to the right
         button_layout.addWidget(self.cancel_button)
         button_layout.addWidget(self.save_button)
         
@@ -84,4 +104,15 @@ class APIKeyDialog(QDialog):
         str
             入力されたAPIキー
         """
-        return self.api_key_input.text() 
+        return self.api_key_input.text()
+
+    def get_base_url(self):
+        """
+        入力されたBase URLを返す
+
+        Returns
+        -------
+        str
+            入力されたBase URL
+        """
+        return self.base_url_input.text().strip()

--- a/src/gui/resources/config.py
+++ b/src/gui/resources/config.py
@@ -14,6 +14,7 @@ class AppConfig:
     
     # 認証設定
     DEFAULT_API_KEY = ""
+    DEFAULT_BASE_URL = ""
     
     # 機能設定
     DEFAULT_HOTKEY = "ctrl+shift+r"

--- a/src/gui/resources/labels.py
+++ b/src/gui/resources/labels.py
@@ -54,6 +54,9 @@ class AppLabels:
     API_KEY_DIALOG_TITLE = "OpenAI APIキー"
     API_KEY_LABEL = "APIキー:"
     API_KEY_INFO = "このアプリケーションを使用するにはOpenAI APIキーが必要です。お持ちでない場合は、https://platform.openai.com/api-keys から取得できます。"
+    AZURE_BASE_URL_LABEL = "Azure OpenAI Base URL:"
+    AZURE_BASE_URL_PLACEHOLDER = "Enter Azure OpenAI Base URL (optional)"
+    AZURE_INFO = "If using Azure OpenAI, enter the Base URL here. Otherwise, leave blank."
     SAVE_BUTTON = "保存"
     CANCEL_BUTTON = "キャンセル"
     

--- a/src/gui/windows/main_window.py
+++ b/src/gui/windows/main_window.py
@@ -45,6 +45,7 @@ class MainWindow(QMainWindow):
         # 設定の読み込み
         self.settings = QSettings(AppConfig.APP_ORGANIZATION, AppConfig.APP_NAME)
         self.api_key = self.settings.value("api_key", AppConfig.DEFAULT_API_KEY)
+        self.base_url = self.settings.value("base_url", AppConfig.DEFAULT_BASE_URL)
         
         # ホットキーとクリップボード設定
         self.hotkey = self.settings.value("hotkey", AppConfig.DEFAULT_HOTKEY)
@@ -79,7 +80,7 @@ class MainWindow(QMainWindow):
         # 初期状態では表示しない - 録音開始時に表示する
         
         try:
-            self.whisper_transcriber = WhisperTranscriber(api_key=self.api_key)
+            self.whisper_transcriber = WhisperTranscriber(api_key=self.api_key, base_url=self.base_url)
         except ValueError:
             self.whisper_transcriber = None
         
@@ -340,15 +341,25 @@ class MainWindow(QMainWindow):
         
         APIキーの入力、保存、検証を行うダイアログを表示します。
         """
-        dialog = APIKeyDialog(self, self.api_key)
+        dialog = APIKeyDialog(self, self.api_key, self.base_url)
         if dialog.exec():
+            old_api_key = self.api_key
+            old_base_url = self.base_url
+
             self.api_key = dialog.get_api_key()
+            self.base_url = dialog.get_base_url()
+
             self.settings.setValue("api_key", self.api_key)
+            self.settings.setValue("base_url", self.base_url)
             
-            # 新しいAPIキーでトランスクライバーを再初期化
+            # 新しいAPIキーとBase URLでトランスクライバーを再初期化
             try:
-                self.whisper_transcriber = WhisperTranscriber(api_key=self.api_key)
-                self.status_bar.showMessage(AppLabels.STATUS_API_KEY_SAVED, 3000)
+                self.whisper_transcriber = WhisperTranscriber(api_key=self.api_key, base_url=self.base_url)
+                if self.api_key != old_api_key or self.base_url != old_base_url:
+                    self.status_bar.showMessage("APIキーとベースURLが更新されました", 3000) # TODO: Add to AppLabels
+                else:
+                    # No actual change, but dialog was accepted
+                    self.status_bar.showMessage("設定ダイアログを閉じました", 3000) # TODO: Add to AppLabels
             except ValueError as e:
                 self.whisper_transcriber = None
                 QMessageBox.warning(self, AppLabels.ERROR_TITLE, AppLabels.ERROR_API_KEY_MISSING)


### PR DESCRIPTION
This change allows you to specify a base URL for OpenAI API calls, enabling compatibility with services like Azure OpenAI.

Modifications include:
- Added Base URL field to the API Key settings dialog.
- Updated OpenAI client initialization to use the provided base URL.
- Stored Base URL in application settings.
- Added relevant configuration options and UI labels.